### PR TITLE
setting target_include_directories correctly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(${TARGET_NAME} ${SOURCE_FILES})
 
 # Allow includes from include/
 target_include_directories(${TARGET_NAME}
-  PUBLIC include/)
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
 if(nfd_PLATFORM STREQUAL PLATFORM_LINUX)
   if(NOT NFD_PORTAL)


### PR DESCRIPTION
I added the current source dir to target_include_dir.
This get the include path to be correctly identified when this lib is used.